### PR TITLE
Add section folding for empty sections

### DIFF
--- a/site/js/main.js
+++ b/site/js/main.js
@@ -183,7 +183,8 @@ function updateThresholdCalculation() {
 		$('#list-entry-' + item.section + '-' + item.details.id).click(function(item) {
 			showDetails(item, 'analyse-');
 		}.bind(null, item.details));
-	}	
+	}
+	updateSectionFolding();
 }
 
 function isUnlocked(section, id) {
@@ -359,6 +360,7 @@ function updateFilter(displayMode, gwuOnly) {
 	}
 	updateGroupVisibility();
 	updateCounts();
+	updateSectionFolding();
 	if (storageAvailable('localStorage')) {
 		localStorage.setItem('gwu-only', gwuOnly); 
 		localStorage.setItem('filter', displayMode);
@@ -453,6 +455,17 @@ function filterWithApiKey(key) {
 			});		
 		}
 	}
+}
+
+function updateSectionFolding() {
+  var sections = $(".section");
+  for (var i = 0; i < sections.length; ++i) {
+    if( $('#' + sections[i].id +' .item:not(.hidden):not(.unlocked)').length == 0) {
+      $(sections[i]).removeAttr("open");
+    } else {
+      $(sections[i]).attr("open", "open");
+    }
+  }
 }
 
 function updateCounts() {


### PR DESCRIPTION
This is an idea I had. 
When sections are empty (all elements are hidden / not unlocked) the section will be folded.

It can still be opened, but it will be folded again if the filter is changed & the section would be empty again.

I used jquery to determine if a section is empty, the query would be like this:
`$('#example-section .item:not(.hidden):not(.unlocked)').length == 0` -> section is beeing folded.

@immortius, what is your opinion on this? 
Do you think this is a useful feature?