### PR TITLE
Add trading post name to skins with differing name

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -126,12 +126,14 @@
 							<span id="selection-buy-gold"></span><span class="base-icon gold-icon" role="img" aria-label="Gold"></span>
 							<span id="selection-buy-silver"></span><span class="base-icon silver-icon" role="img" aria-label="Silver"></span>
 							<span id="selection-buy-copper"></span><span class="base-icon copper-icon" role="img" aria-label="Copper"></span>
+							<span id="selection-buy-name"></span>
 							</div>
 							<div id="selection-sell-pricing">Sell Price: 
 							<span id="selection-sell-gold"></span><span class="base-icon gold-icon" role="img" aria-label="Gold"></span>
 							<span id="selection-sell-silver"></span><span class="base-icon silver-icon" role="img" aria-label="Silver"></span>
 							<span id="selection-sell-copper"></span><span class="base-icon copper-icon" role="img" aria-label="Copper"></span>
-							</div>
+              <span id="selection-sell-name"></span>
+              </div>
 						</div>
 						<div id="selection-vendors">
 						 <h3>Vendors</h3>
@@ -177,12 +179,14 @@
 								<span id="analyse-selection-buy-gold"></span><span class="base-icon gold-icon" role="img" aria-label="Gold"></span>
 								<span id="analyse-selection-buy-silver"></span><span class="base-icon silver-icon" role="img" aria-label="Silver"></span>
 								<span id="analyse-selection-buy-copper"></span><span class="base-icon copper-icon" role="img" aria-label="Copper"></span>
-								</div>
-								<div id="analyse-selection-sell-pricing">Sell Price: 
+                <span id="analyse-selection-buy-name"></span>
+                </div>
+								<div id="analyse-selection-sell-pricing">Sell Price:
 								<span id="analyse-selection-sell-gold"></span><span class="base-icon gold-icon" role="img" aria-label="Gold"></span>
 								<span id="analyse-selection-sell-silver"></span><span class="base-icon silver-icon" role="img" aria-label="Silver"></span>
 								<span id="analyse-selection-sell-copper"></span><span class="base-icon copper-icon" role="img" aria-label="Copper"></span>
-								</div>
+                <span id="analyse-selection-sell-name"></span>
+                </div>
 							</div>
 							<div id="analyse-selection-vendors">
 							 <h3>Vendors</h3>

--- a/site/js/main.js
+++ b/site/js/main.js
@@ -629,9 +629,9 @@ function calculateTotalValue(tpItems, priceFunc) {
 function getSellPrice(item) {
 	var itemValue = NaN;
 	if (item.priceData != null) {
-		itemValue = item.priceData.sellPrice;
+		itemValue = item.priceData.bestSellPrice.price;
 		if (isNaN(itemValue)) {
-			itemValue = item.priceData.buyPrice;
+			itemValue = item.priceData.bestBuyPrice.price;
 		}
 	}
 	var vendorPrice = getVendorPrice(item);
@@ -644,9 +644,9 @@ function getSellPrice(item) {
 function getBuyPrice(item) {
 	var itemValue = NaN;
 	if (item.priceData != null) {
-		itemValue = item.priceData.buyPrice;
+		itemValue = item.priceData.bestBuyPrice.price;
 		if (isNaN(itemValue)) {
-			itemValue = item.priceData.sellPrice;
+			itemValue = item.priceData.bestSellPrice.price;
 		}
 	}
 	var vendorPrice = getVendorPrice(item);
@@ -954,19 +954,29 @@ function showDetails(item, prefix) {
 	}
 	
 	if (item.priceData) {
-		if (item.priceData.buyPrice) {
-			$('#' + prefix + 'selection-buy-gold').text(Math.floor(item.priceData.buyPrice / 10000));
-			$('#' + prefix + 'selection-buy-silver').text(Math.floor(item.priceData.buyPrice / 100) % 100);
-			$('#' + prefix + 'selection-buy-copper').text(item.priceData.buyPrice % 100);
+		if (item.priceData.bestBuyPrice.price) {
+		  if(item.priceData.bestBuyPrice.itemName != item.name) {
+		    $('#' + prefix + 'selection-buy-name').text("(" + item.priceData.bestBuyPrice.itemName + ")");
+		  } else {
+		    $('#' + prefix + 'selection-buy-name').text("");
+		  }
+			$('#' + prefix + 'selection-buy-gold').text(Math.floor(item.priceData.bestBuyPrice.price / 10000));
+			$('#' + prefix + 'selection-buy-silver').text(Math.floor(item.priceData.bestBuyPrice.price / 100) % 100);
+			$('#' + prefix + 'selection-buy-copper').text(item.priceData.bestBuyPrice.price % 100);
 		} else {
 			$('#' + prefix + 'selection-buy-gold').text('0');
 			$('#' + prefix + 'selection-buy-silver').text('0');
 			$('#' + prefix + 'selection-buy-copper').text('0');
 		}
-		if (item.priceData.sellPrice) {
-			$('#' + prefix + 'selection-sell-gold').text(Math.floor(item.priceData.sellPrice / 10000));
-			$('#' + prefix + 'selection-sell-silver').text(Math.floor(item.priceData.sellPrice / 100) % 100);
-			$('#' + prefix + 'selection-sell-copper').text(item.priceData.sellPrice % 100);
+		if (item.priceData.bestSellPrice.price) {
+		   if(item.priceData.bestSellPrice.itemName != item.name) {
+		     $('#' + prefix + 'selection-sell-name').text("(" + item.priceData.bestSellPrice.itemName + ")");
+       } else {
+      	 $('#' + prefix + 'selection-sell-name').text("");
+       }
+			$('#' + prefix + 'selection-sell-gold').text(Math.floor(item.priceData.bestSellPrice.price / 10000));
+			$('#' + prefix + 'selection-sell-silver').text(Math.floor(item.priceData.bestSellPrice.price / 100) % 100);
+			$('#' + prefix + 'selection-sell-copper').text(item.priceData.bestSellPrice.price % 100);
 		} else {
 			$('#' + prefix + 'selection-sell-gold').text('-');
 			$('#' + prefix + 'selection-sell-silver').text('-');

--- a/src/main/java/au/net/immortius/wardrobe/gw2api/Skins.java
+++ b/src/main/java/au/net/immortius/wardrobe/gw2api/Skins.java
@@ -4,13 +4,9 @@ import au.net.immortius.wardrobe.config.Config;
 import au.net.immortius.wardrobe.config.UnlockCategoryConfig;
 import au.net.immortius.wardrobe.gw2api.entities.ItemData;
 import com.google.common.base.Strings;
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Maps;
 import com.google.gson.Gson;
 
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 
@@ -33,11 +29,7 @@ public class Skins extends CacheAccessor<ItemData> {
 
     public Optional<String> getSkinType(int id) {
         Optional<ItemData> itemData = get(id);
-        if (itemData.isPresent()) {
-            return Optional.of(getSkinType(itemData.get()));
-        } else {
-            return Optional.empty();
-        }
+        return itemData.map(this::getSkinType);
     }
 
     public String getSkinType(ItemData itemData) {

--- a/src/main/java/au/net/immortius/wardrobe/site/GenerateContent.java
+++ b/src/main/java/au/net/immortius/wardrobe/site/GenerateContent.java
@@ -1,6 +1,7 @@
 package au.net.immortius.wardrobe.site;
 
 import au.net.immortius.wardrobe.config.Config;
+import au.net.immortius.wardrobe.config.Grouping;
 import au.net.immortius.wardrobe.config.UnlockCategoryConfig;
 import au.net.immortius.wardrobe.gw2api.Chatcode;
 import au.net.immortius.wardrobe.gw2api.Rarity;
@@ -8,7 +9,6 @@ import au.net.immortius.wardrobe.gw2api.Unlocks;
 import au.net.immortius.wardrobe.gw2api.entities.ItemData;
 import au.net.immortius.wardrobe.imagemap.IconDetails;
 import au.net.immortius.wardrobe.imagemap.ImageMap;
-import au.net.immortius.wardrobe.config.Grouping;
 import au.net.immortius.wardrobe.site.entities.*;
 import au.net.immortius.wardrobe.util.ColorUtil;
 import au.net.immortius.wardrobe.vendors.entities.VendorData;
@@ -36,7 +36,6 @@ import java.util.stream.Collectors;
  */
 public class GenerateContent {
 
-    private static Logger logger = LoggerFactory.getLogger(GenerateContent.class);
     private static final String GENERAL_GROUP_NAME = "General";
     private static final String UNCLASSIFIED_GROUP_NAME = "New";
     private static final String GOLD = "gold";
@@ -44,7 +43,7 @@ public class GenerateContent {
     private static final String TRADINGPOST = "tp";
     private static final String GUARANTEED_WARDROBE_UNLOCK = "gwu";
     private static final String CRAFT = "craft";
-    private static final GenericType<Map<Integer, Price>> PRICE_MAP_TYPE = new GenericType<Map<Integer, Price>>() {
+    private static final GenericType<Map<Integer, TradingPostEntry>> PRICE_MAP_TYPE = new GenericType<Map<Integer, TradingPostEntry>>() {
     };
     private static final GenericType<Map<Integer, Collection<Integer>>> UNLOCK_ITEM_MULTIMAP = new GenericType<Map<Integer, Collection<Integer>>>() {
     };
@@ -52,7 +51,7 @@ public class GenerateContent {
     };
     private static final GenericType<Set<Integer>> INTEGER_SET_TYPE = new GenericType<Set<Integer>>() {
     };
-
+    private static Logger logger = LoggerFactory.getLogger(GenerateContent.class);
     private Gson gson;
     private Config config;
     private Unlocks unlocks;
@@ -89,9 +88,9 @@ public class GenerateContent {
             try (Reader unlockToSkinMappingReader = Files.newBufferedReader(config.paths.getUnlockItemsPath().resolve(unlockCategoryConfig.id + ".json"))) {
                 unlockItemMap = gson.fromJson(unlockToSkinMappingReader, UNLOCK_ITEM_MULTIMAP.getType());
                 itemUnlockMap = Maps.newHashMap();
-                unlockItemMap.entrySet().forEach(x -> {
-                    for (int item : x.getValue()) {
-                        itemUnlockMap.put(item, x.getKey());
+                unlockItemMap.forEach((key, value) -> {
+                    for (int item : value) {
+                        itemUnlockMap.put(item, key);
                     }
                 });
             }
@@ -160,7 +159,9 @@ public class GenerateContent {
                             itemGroup.content.add(unlock);
                         }
                     }
-                    itemGroup.content.sort(Comparator.comparing((UnlockData a) -> a.rarity).thenComparing(a -> a.name).thenComparing(a -> a.id));
+                    itemGroup.content.sort(Comparator.comparing((UnlockData a) -> a.rarity)
+                            .thenComparing(a -> a.name)
+                            .thenComparing(a -> a.id));
                     groups.add(itemGroup);
                 } catch (JsonSyntaxException e) {
                     logger.error("Failed to read {}", groupFile, e);
@@ -238,7 +239,6 @@ public class GenerateContent {
                 finalVendors.addAll(cheapest);
             }
             unlock.getVendors().clear();
-            ;
             unlock.getVendors().addAll(finalVendors);
         }
     }
@@ -267,6 +267,7 @@ public class GenerateContent {
                         for (VendorInfo existingVendor : unlock.getVendors()) {
                             if (existingVendor.vendorName.equals(vendor.name)) {
                                 duplicateVendor = true;
+                                break;
                             }
                         }
                         if (duplicateVendor) {
@@ -347,20 +348,35 @@ public class GenerateContent {
     private void applyPrices(Gson gson, UnlockCategoryConfig unlockCategoryConfig, Map<Integer, UnlockData> unlockDataMap) throws IOException {
         if (Files.exists(config.paths.getUnlockPricesPath().resolve(unlockCategoryConfig.id + ".json"))) {
             try (Reader priceLookupReader = Files.newBufferedReader(config.paths.getUnlockPricesPath().resolve(unlockCategoryConfig.id + ".json"))) {
-                Map<Integer, Price> priceLookup = gson.fromJson(priceLookupReader, PRICE_MAP_TYPE.getType());
-                for (Map.Entry<Integer, Price> entry : priceLookup.entrySet()) {
-                    UnlockData unlockData = unlockDataMap.get(entry.getKey());
+                Map<Integer, TradingPostEntry> priceLookup = gson.fromJson(priceLookupReader, PRICE_MAP_TYPE.getType());
+                for (Map.Entry<Integer, TradingPostEntry> entry : priceLookup.entrySet()) {
+                    Integer itemId = entry.getKey();
+                    UnlockData unlockData = unlockDataMap.get(itemId);
                     if (unlockData == null) {
-                        logger.error("Found price for missing unlock {} of type {}", entry.getKey(), unlockCategoryConfig.id);
+                        logger.error("Found price for missing unlock {} of type {}", itemId, unlockCategoryConfig.id);
                     } else {
-                        unlockData.priceData = entry.getValue();
+                        TradingPostEntry tpEntry = entry.getValue();
+                        PriceEntry bestBuyPrice = tpEntry.getBestBuyPrice();
+                        readItem(bestBuyPrice.getItemId())
+                                .ifPresent(i -> bestBuyPrice.setItemName(i.getName()));
+                        PriceEntry bestSellPrice = tpEntry.getBestSellPrice();
+                        readItem(bestSellPrice.getItemId())
+                                .ifPresent(i -> bestSellPrice.setItemName(i.getName()));
+                        unlockData.priceData = tpEntry;
                         unlockData.sources.add(GOLD);
-                        unlockData.sources.add(TRADINGPOST);
                         unlockData.sources.add(TRADINGPOST);
                     }
 
                 }
             }
+        }
+    }
+
+    private Optional<ItemData> readItem(Integer id) {
+        try (Reader itemReader = Files.newBufferedReader(config.paths.getItemPath().resolve(id + ".json"))) {
+            return Optional.ofNullable(gson.fromJson(itemReader, ItemData.class));
+        } catch (IOException ex) {
+            return Optional.empty();
         }
     }
 

--- a/src/main/java/au/net/immortius/wardrobe/site/entities/Price.java
+++ b/src/main/java/au/net/immortius/wardrobe/site/entities/Price.java
@@ -1,9 +1,0 @@
-package au.net.immortius.wardrobe.site.entities;
-
-/**
- * Trading post price information for an unlock
- */
-public class Price {
-    public Integer buyPrice;
-    public Integer sellPrice;
-}

--- a/src/main/java/au/net/immortius/wardrobe/site/entities/PriceEntry.java
+++ b/src/main/java/au/net/immortius/wardrobe/site/entities/PriceEntry.java
@@ -1,0 +1,35 @@
+package au.net.immortius.wardrobe.site.entities;
+
+import javax.annotation.Nullable;
+
+/**
+ * Trading post price information for an unlock
+ */
+public class PriceEntry {
+    private final Integer itemId; //Actual item, since some items share skins
+    private final Integer price;
+    @Nullable
+    private String itemName;
+
+    public PriceEntry(Integer itemId, Integer price) {
+        this.itemId = itemId;
+        this.price = price;
+    }
+
+    public Integer getItemId() {
+        return itemId;
+    }
+
+    public Integer getPrice() {
+        return price;
+    }
+
+    @Nullable
+    public String getItemName() {
+        return itemName;
+    }
+
+    public void setItemName(@Nullable String itemName) {
+        this.itemName = itemName;
+    }
+}

--- a/src/main/java/au/net/immortius/wardrobe/site/entities/TradingPostEntry.java
+++ b/src/main/java/au/net/immortius/wardrobe/site/entities/TradingPostEntry.java
@@ -1,0 +1,19 @@
+package au.net.immortius.wardrobe.site.entities;
+
+public class TradingPostEntry {
+  private final PriceEntry bestSellPrice;
+  private final PriceEntry bestBuyPrice;
+
+  public TradingPostEntry(PriceEntry bestSellPrice, PriceEntry bestBuyPrice) {
+    this.bestSellPrice = bestSellPrice;
+    this.bestBuyPrice = bestBuyPrice;
+  }
+
+  public PriceEntry getBestSellPrice() {
+    return bestSellPrice;
+  }
+
+  public PriceEntry getBestBuyPrice() {
+    return bestBuyPrice;
+  }
+}

--- a/src/main/java/au/net/immortius/wardrobe/site/entities/UnlockData.java
+++ b/src/main/java/au/net/immortius/wardrobe/site/entities/UnlockData.java
@@ -20,7 +20,7 @@ public class UnlockData {
     public String chatcode;
     public Set<String> sources;
     private List<VendorInfo> vendors;
-    public Price priceData;
+    public TradingPostEntry priceData;
 
     /**
      * @return The list of vendors from which this unlock can be purchased

--- a/src/test/java/DeconstructContent.java
+++ b/src/test/java/DeconstructContent.java
@@ -241,7 +241,7 @@ public class DeconstructContent {
         try (Reader reader = Files.newBufferedReader(contentPath)) {
             ContentData data = gson.fromJson(reader, ContentData.class);
             for (UnlockCategoryData itemCategory : data.items) {
-                Map<Integer, Price> categoryLookup = Maps.newLinkedHashMap();
+                Map<Integer, TradingPostEntry> categoryLookup = Maps.newLinkedHashMap();
                 for (UnlockGroupData groupData : itemCategory.groups) {
                     for (UnlockData unlockData : groupData.content) {
                         if (unlockData.priceData != null) {


### PR DESCRIPTION
I've added the Item name to the Skin name for Tradingpost prices where they don't match.
This will also show different Items for Buy/Sell price if they differ.

Here is an example:
https://imgur.com/a/uB3ZJCa

It works in both views: Analyse and the browsing view